### PR TITLE
feat: new sensors, phase mode select, charging rule services, and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,66 +6,215 @@
 
 [![hacs][hacsbadge]][hacs]
 
-<a href="https://www.buymeacoffee.com/mbsoftware"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=mbsoftware&button_colour=FFDD00&font_colour=000000&font_family=Cookie&outline_colour=000000&coffee_colour=ffffff" /></a>
-
 ### Integration for Homeassistant to view and control devices (EV charging stations and powermeters) connected to a cFos Powerbrain charging controller or cFos charging manager
+
+> **Fork by [guibrazlima](https://github.com/guibrazlima)** — extends the original integration with additional EVSE sensors and new services for programmatic control of charging rules and global parameters.
 
 ## Features
 
 - Automatically discovers and creates devices (powermeters and charging stations) connected to a Powerbrain controller
 - Creates sensors to read values from power meters (voltage, current, energy, ...)
 - Creates switches to control charging stations (enable charging, enable charging rules, set charging current, ...)
-- Adds a Homeassistant service to enter RFID/PIN codes into EVSE/wallboxes, allowing all kind of automations to authorize charging or change charging rules.
-- Adds a Homeassistant service to send power meter values to an HTTP input meter in the charging manager
+- Adds a Homeassistant service to enter RFID/PIN codes into EVSE/wallboxes
+- Adds a Homeassistant service to send power meter values to an HTTP input meter
 - Adds a Homeassistant service to set global charging manager variables
+- **[NEW]** Additional EVSE sensors (session energy, pause reason, CP/PP state, phases, ...)
+- **[NEW]** Service to set global Charging Manager parameters (`set_params`)
+- **[NEW]** Service to create/replace EVSE charging rules (`set_charging_rules`)
+- **[NEW]** Service to read current EVSE charging rules (`get_charging_rules`)
 
-\*\*Please note that this integration is still in an early stage and functionality will likely be extended in the future. If you experience any issues or bugs or if you have a feature request, please raise an issue on Github. If you want to contribute, please also read the [Contribution guidelines](CONTRIBUTING.md) .
+## Sensors
 
-If you want to do me a favor you can [buy me a coffee] or if you want to purchase one of the great cFos Power Brain Wallboxes you can get a <b>20€ discount</b> on all wallboxes using the coupon code <b>mb-software</b> or my affiliate link to the <a href="https://shop.cfos-emobility.de/markus-bitzer">cFos emobility shop</a>.
+### Power Meter sensors
 
-![example][exampleimg]
+| Sensor | Unit | Description |
+|--------|------|-------------|
+| Power | W / VA | Current active power |
+| Import | kWh | Total imported energy |
+| Export | kWh | Total exported energy |
+| Current L1/L2/L3 | A | Phase currents |
+| Voltage L1/L2/L3 | V | Phase voltages |
 
-## Installation using HACS
+### EVSE / Wallbox sensors
 
-This integration can be found as a default repository in the <a href="https://hacs.xyz">Home Assistant Community Store</a>.
+| Sensor | Unit | Description |
+|--------|------|-------------|
+| Charging Power | W | Current charging power |
+| Total Charging Energy | kWh | Total energy charged (lifetime) |
+| **Session Energy** | kWh | Energy charged in current session (resets on unplug) |
+| State | — | Wallbox state: Standby / Car connected / Charging / Error / Offline |
+| Current L1/L2/L3 | A | Phase charging currents |
+| **Last Set Charging Current** | A | Last current commanded by the Charging Manager |
+| **Used Phases** | — | Number of phases currently in use |
+| **Pause Reason** | — | Why charging is paused: None / Current limit / Charging rules / Manual pause / Phase switch / Error |
+| **Pause Time Remaining** | s | Seconds until end of minimum pause (0 = not paused) |
+| **CP State** | — | Control Pilot state (e.g. "Vehicle detected") |
+| **PP State** | — | Proximity Pilot state — cable detection (e.g. "no cable") |
+| **Total Charging Duration** | s | Cumulative total charging time in seconds |
 
-if you have HACS installed you can simply download and update the integration using HACS.
+**Bold** = added in this fork.
+
+## Services
+
+### `powerbrain.enter_rfid`
+Enter an RFID or PIN code into a charging station to authorize or stop charging.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `rfid` | ✅ | RFID or PIN (digits) |
+| `dev_id` | — | EVSE device ID (e.g. `E1`). If omitted, auto-assigned. |
+| `powerbrain_host` | — | Host address if multiple Powerbrain instances are configured |
+
+---
+
+### `powerbrain.set_meter`
+Send power meter values to an HTTP input meter in the Charging Manager.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `dev_id` | ✅ | Meter device ID (e.g. `M1`) |
+| `power` | — | Active power (W or VA) |
+| `is_va` | — | True if power is in VA |
+| `voltage_l1/l2/l3` | — | Phase voltages (V) |
+| `current_l1/l2/l3` | — | Phase currents (A) |
+| `import_energy` | — | Imported energy (kWh) |
+| `export_energy` | — | Exported energy (kWh) |
+| `powerbrain_host` | — | Host address if multiple instances |
+
+---
+
+### `powerbrain.set_variable`
+Set the value of a Charging Manager variable.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `variable` | ✅ | Variable name |
+| `value` | ✅ | Value to set |
+| `powerbrain_host` | — | Host address if multiple instances |
+
+---
+
+### `powerbrain.set_params` *(new)*
+Set global Charging Manager parameters. Only include the keys you want to change.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `min_pause_time` | — | Minimum pause between sessions (seconds, default 300) |
+| `disable_policy` | — | On device disable: `0`=disable EVSE, `1`=use min. current, `-1`=free charging |
+| `max_total_current` | — | Total installed power limit (mA) |
+| `lb_enabled` | — | Enable/disable load balancing |
+| `feed_in_tariff` | — | Feed-in tariff (currency/kWh) |
+| `surplus_expr` | — | Expression to calculate surplus power |
+| `powerbrain_host` | — | Host address if multiple instances |
+
+Example automation — reduce minimum pause time to 60s:
+```yaml
+service: powerbrain.set_params
+data:
+  min_pause_time: 60
+```
+
+---
+
+### `powerbrain.set_charging_rules` *(new)*
+Replace the charging rules for a specific EVSE. All existing rules are overwritten.
+
+> ⚠️ The cFos API marks `charging_rules` as **work in progress** and the format may change in future firmware versions.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `dev_id` | ✅ | EVSE device ID (e.g. `E1`) |
+| `rules` | ✅ | Array of rule objects (see below) |
+| `powerbrain_host` | — | Host address if multiple instances |
+
+**Rule object fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `days` | int | Weekday bitfield: bit0=Mon … bit6=Sun. `127` = all days |
+| `mode` | int | `0`=absolute current, `1`=relative, `2`=solar current, `3`=relative solar, `4`=solar minus value, `5`=solar surplus |
+| `current` | int | Charging current in mA |
+| `enabled` | bool | `true` = rule active |
+| `time` | int | Start time in minutes after midnight (time-based rules) |
+| `dur` | int | Duration in minutes (time-based rules) |
+| `udur` | int | Undercut duration in seconds |
+| `expr` | str | Expression string (expression-based rules) |
+| `input` | str | Input string (input-based rules) |
+| `price_level` | int | Price level (cost-based rules) |
+| `solar` | int | Solar current in mA (solar-based rules) |
+
+Example — set a time-based rule to charge at 32A every night from 22:15 for 45 minutes:
+```yaml
+service: powerbrain.set_charging_rules
+data:
+  dev_id: E1
+  rules:
+    - days: 127         # all days
+      mode: 0           # absolute current
+      current: 32000    # 32A in mA
+      enabled: true
+      time: 1335        # 22:15 in minutes after midnight
+      dur: 45           # 45 minutes
+```
+
+Example — clear all rules (back to Charging Manager default behaviour):
+```yaml
+service: powerbrain.set_charging_rules
+data:
+  dev_id: E1
+  rules: []
+```
+
+---
+
+### `powerbrain.get_charging_rules` *(new)*
+Retrieve and log the current charging rules for an EVSE. Rules are written to the Home Assistant log at INFO level — useful for debugging.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `dev_id` | ✅ | EVSE device ID (e.g. `E1`) |
+| `powerbrain_host` | — | Host address if multiple instances |
+
+---
+
+## Installation using HACS (this fork)
+
+To install this fork via HACS as a custom repository:
+
+1. In HA go to **HACS → Integrations → ⋮ → Custom repositories**
+2. Add `https://github.com/guibrazlima/homeassistant-powerbrain` as category **Integration**
+3. Search for "cFos Powerbrain" and install
+4. Restart Home Assistant
 
 ## Manual Installation
 
-1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).
-2. If you do not have a `custom_components` directory (folder) there, you need to create it.
-3. In the `custom_components` directory (folder) create a new folder called `powerbrain`.
-4. Download _all_ the files from the `custom_components/powerbrain/` directory (folder) in this repository.
-5. Place the files you downloaded in the new directory (folder) you created.
-6. Restart Home Assistant
-7. In the HA UI go to "Configuration" -> "Integrations" click "+" and search for "cFos Powerbrain"
+1. Open the directory for your HA configuration (where `configuration.yaml` is).
+2. Create `custom_components/` if it doesn't exist.
+3. Create `custom_components/powerbrain/` inside it.
+4. Download all files from `custom_components/powerbrain/` in this repository.
+5. Restart Home Assistant.
+6. Go to **Settings → Integrations → Add** and search for "cFos Powerbrain".
 
-## Configuration is done in the UI
+## Configuration
 
-Simply enter the host (IP address) of your powerbrain controller in the local network and choose the update intervall [seconds] the integration uses to poll the sensor values.
+Enter the host (IP address or URL) of your Powerbrain controller and the polling interval in seconds.
 
 ![config1img]
 ![config2img]
 
 ## Contributions are welcome!
 
-If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
+Please read the [Contribution guidelines](CONTRIBUTING.md).
 
 ---
 
-[buy me a coffee]: https://www.buymeacoffee.com/mbsoftware
-[commits-shield]: https://img.shields.io/github/commit-activity/y/mb-software/homeassistant-powerbrain.svg?style=for-the-badge
-[commits]: https://github.com/mb-software/homeassistant-powerbrain/commits/main
+[commits-shield]: https://img.shields.io/github/commit-activity/y/guibrazlima/homeassistant-powerbrain.svg?style=for-the-badge
+[commits]: https://github.com/guibrazlima/homeassistant-powerbrain/commits/master
 [hacs]: https://hacs.xyz
-[hacsbadge]: https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge
+[hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
 [exampleimg]: doc/evse.png
 [config1img]: doc/ConfigFlow.png
 [config2img]: doc/device_discovery.png
-[license-shield]: https://img.shields.io/github/license/mb-software/homeassistant-powerbrain.svg?style=for-the-badge
-[maintenance-shield]: https://img.shields.io/badge/maintainer-%40mb-software-blue.svg?style=for-the-badge
-[pre-commit]: https://github.com/pre-commit/pre-commit
-[pre-commit-shield]: https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/mb-software/homeassistant-powerbrain.svg?style=for-the-badge
-[releases]: https://github.com/mb-software/homeassistant-powerbrain/releases
-[user_profile]: https://github.com/mb-software
+[license-shield]: https://img.shields.io/github/license/guibrazlima/homeassistant-powerbrain.svg?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/release/guibrazlima/homeassistant-powerbrain.svg?style=for-the-badge
+[releases]: https://github.com/guibrazlima/homeassistant-powerbrain/releases

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ data:
 ### `powerbrain.set_charging_rules` *(new)*
 Replace the charging rules for a specific EVSE. All existing rules are overwritten.
 
-> ⚠️ The cFos API marks `charging_rules` as **work in progress** and the format may change in future firmware versions.
+Uses the native cFos `get_devices` / `set_device` API (same as the cFos web UI), which correctly persists rules across reboots.
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -127,34 +127,58 @@ Replace the charging rules for a specific EVSE. All existing rules are overwritt
 | `rules` | ✅ | Array of rule objects (see below) |
 | `powerbrain_host` | — | Host address if multiple instances |
 
-**Rule object fields:**
+**Rule object fields (cFos native format):**
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `cmt` | str | Comment / label shown in the cFos UI |
 | `days` | int | Weekday bitfield: bit0=Mon … bit6=Sun. `127` = all days |
-| `mode` | int | `0`=absolute current, `1`=relative, `2`=solar current, `3`=relative solar, `4`=solar minus value, `5`=solar surplus |
-| `current` | int | Charging current in mA |
-| `enabled` | bool | `true` = rule active |
+| `ctype` | int | Condition type: `0`=none/time window, `1`=solar surplus, … |
+| `atype` | int | Action type: `0`=set current (mA), `10`=pause |
+| `aexpr` | int | Action value: current in mA for `atype=0`, `1` for `atype=10` |
 | `time` | int | Start time in minutes after midnight (time-based rules) |
-| `dur` | int | Duration in minutes (time-based rules) |
+| `dur` | int | Duration in minutes |
 | `udur` | int | Undercut duration in seconds |
-| `expr` | str | Expression string (expression-based rules) |
-| `input` | str | Input string (input-based rules) |
-| `price_level` | int | Price level (cost-based rules) |
-| `solar` | int | Solar current in mA (solar-based rules) |
+| `flags` | int | `16`=normal, `18`=end-on-finish |
+| `ena` | bool | `true` = rule enabled |
+| `id` | int | Rule id; use `0` for auto-assign |
+| `cexpr` | int | Condition threshold (e.g. solar power in W for `ctype=1`) |
 
-Example — set a time-based rule to charge at 32A every night from 22:15 for 45 minutes:
+Example — time-based rule: charge at 16A every night from 22:00 for 3 hours:
 ```yaml
 service: powerbrain.set_charging_rules
 data:
   dev_id: E1
   rules:
-    - days: 127         # all days
-      mode: 0           # absolute current
-      current: 32000    # 32A in mA
-      enabled: true
-      time: 1335        # 22:15 in minutes after midnight
-      dur: 45           # 45 minutes
+    - cmt: "Overnight cheap rate"
+      days: 127       # all days
+      ctype: 0        # no condition / time window
+      atype: 0        # set current
+      aexpr: 16000    # 16A in mA
+      time: 1320      # 22:00 = 22 × 60 minutes
+      dur: 180        # 3 hours
+      udur: 0
+      flags: 16
+      ena: true
+      id: 0
+```
+
+Example — pause rule: pause for 5 min if solar surplus < 3000W:
+```yaml
+service: powerbrain.set_charging_rules
+data:
+  dev_id: E1
+  rules:
+    - cmt: "Pause low solar"
+      days: 127
+      ctype: 1        # solar surplus condition
+      atype: 10       # pause
+      aexpr: 1
+      cexpr: 3000     # threshold: 3000W
+      udur: 300       # undercut duration 5 min
+      flags: 18
+      ena: true
+      id: 0
 ```
 
 Example — clear all rules (back to Charging Manager default behaviour):

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - **[NEW]** Additional EVSE sensors (session energy, pause reason, CP/PP state, phases, ...)
 - **[NEW]** Service to set global Charging Manager parameters (`set_params`)
 - **[NEW]** Service to create/replace EVSE charging rules (`set_charging_rules`)
+- **[NEW]** Service to update a single rule by label without affecting others (`update_charging_rule`)
 - **[NEW]** Service to read current EVSE charging rules (`get_charging_rules`)
 
 ## Sensors
@@ -115,6 +116,44 @@ data:
 ```
 
 ---
+
+### `powerbrain.update_charging_rule` *(new)*
+Update a single charging rule identified by its `cmt` label, without affecting other rules.
+
+This is the recommended service for automation use-cases (e.g. EV smart charging) where only the start time or duration needs to change — other rules like solar-pause rules remain untouched.
+
+If no rule with the given `cmt` label exists, a new rule is appended automatically.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `dev_id` | ✅ | EVSE device ID (e.g. `E1`) |
+| `cmt` | ✅ | Label of the rule to update (must match exactly) |
+| `time` | — | New start time in minutes since midnight (e.g. `1320` = 22:00) |
+| `dur` | — | New duration in minutes |
+| `aexpr` | — | New charging current in mA (for `atype=0` rules) |
+| `ena` | — | Enable (`true`) or disable (`false`) the rule |
+| `days` | — | New weekday bitfield (bit0=Mon … bit6=Sun, `127`=all) |
+| `powerbrain_host` | — | Host address if multiple instances (optional) |
+
+Example — update the EV overnight rule to start at 23:00 for 2 hours:
+```yaml
+service: powerbrain.update_charging_rule
+data:
+  dev_id: E1
+  cmt: "EV Carregamento Nocturno"
+  time: 1380   # 23:00 = 23 × 60
+  dur: 120     # 2 hours
+  ena: true
+```
+
+Example — disable the rule without deleting it:
+```yaml
+service: powerbrain.update_charging_rule
+data:
+  dev_id: E1
+  cmt: "EV Carregamento Nocturno"
+  ena: false
+```
 
 ### `powerbrain.set_charging_rules` *(new)*
 Replace the charging rules for a specific EVSE. All existing rules are overwritten.

--- a/custom_components/powerbrain/__init__.py
+++ b/custom_components/powerbrain/__init__.py
@@ -104,9 +104,54 @@ async def async_setup(hass: HomeAssistant, config):
                 value = call.data.get("value")
                 hass.async_add_executor_job(brain.set_variable, name, value)
 
+    async def handle_set_params(call):
+        """Set global Charging Manager parameters."""
+        entries = hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
+            brain = hass.data[DOMAIN][entry.entry_id]
+            host = call.data.get("powerbrain_host", "")
+            if host == "" or host == brain.host:
+                params = {
+                    k: v
+                    for k, v in call.data.items()
+                    if k != "powerbrain_host"
+                }
+                hass.async_add_executor_job(brain.set_params, params)
+
+    async def handle_set_charging_rules(call):
+        """Set charging rules for a specific EVSE."""
+        entries = hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
+            brain = hass.data[DOMAIN][entry.entry_id]
+            host = call.data.get("powerbrain_host", "")
+            if host == "" or host == brain.host:
+                dev_id = call.data.get("dev_id")
+                rules = call.data.get("rules", [])
+                if dev_id in brain.devices:
+                    hass.async_add_executor_job(
+                        brain.devices[dev_id].set_charging_rules, rules
+                    )
+
+    async def handle_get_charging_rules(call):
+        """Log current charging rules for a specific EVSE (debug helper)."""
+        entries = hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
+            brain = hass.data[DOMAIN][entry.entry_id]
+            host = call.data.get("powerbrain_host", "")
+            if host == "" or host == brain.host:
+                dev_id = call.data.get("dev_id")
+                if dev_id in brain.devices:
+                    rules = await hass.async_add_executor_job(
+                        brain.devices[dev_id].get_charging_rules
+                    )
+                    _LOGGER.info("Charging rules for %s: %s", dev_id, rules)
+
     hass.services.async_register(DOMAIN, "enter_rfid", handle_enter_rfid)
     hass.services.async_register(DOMAIN, "set_meter", handle_set_meter)
     hass.services.async_register(DOMAIN, "set_variable", handle_set_variable)
+    hass.services.async_register(DOMAIN, "set_params", handle_set_params)
+    hass.services.async_register(DOMAIN, "set_charging_rules", handle_set_charging_rules)
+    hass.services.async_register(DOMAIN, "get_charging_rules", handle_get_charging_rules)
 
     return True
 

--- a/custom_components/powerbrain/__init__.py
+++ b/custom_components/powerbrain/__init__.py
@@ -134,6 +134,54 @@ async def async_setup(hass: HomeAssistant, config):
                         brain.devices[dev_id].set_charging_rules, rules
                     )
 
+    async def handle_update_charging_rule(call):
+        """Update a single charging rule identified by its cmt label.
+
+        Reads current rules, finds the rule with the matching cmt,
+        applies the provided field updates, and writes all rules back.
+        If no rule with that cmt exists, a new one is appended.
+        """
+        entries = hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
+            brain = hass.data[DOMAIN][entry.entry_id]
+            host = call.data.get("powerbrain_host", "")
+            if host == "" or host == brain.host:
+                dev_id = call.data.get("dev_id")
+                cmt = call.data.get("cmt")
+                updates = {k: v for k, v in call.data.items()
+                           if k not in ("dev_id", "cmt", "powerbrain_host")}
+                if dev_id not in brain.devices:
+                    continue
+                rules = await hass.async_add_executor_job(
+                    brain.devices[dev_id].get_charging_rules
+                )
+                found = False
+                new_rules = []
+                for rule in rules:
+                    if rule.get("cmt") == cmt:
+                        new_rules.append({**rule, **updates})
+                        found = True
+                    else:
+                        new_rules.append(rule)
+                if not found:
+                    new_rule = {
+                        "cmt": cmt, "days": 127, "ctype": 0, "atype": 0,
+                        "aexpr": 32000, "udur": 0, "flags": 16, "ena": True, "id": 0,
+                    }
+                    new_rule.update(updates)
+                    new_rules.append(new_rule)
+                    _LOGGER.info(
+                        "update_charging_rule: rule '%s' not found in %s, appended new rule",
+                        cmt, dev_id,
+                    )
+                await hass.async_add_executor_job(
+                    brain.devices[dev_id].set_charging_rules, new_rules
+                )
+                _LOGGER.info(
+                    "update_charging_rule: updated rule '%s' on %s: %s",
+                    cmt, dev_id, updates,
+                )
+
     async def handle_get_charging_rules(call):
         """Log current charging rules for a specific EVSE (debug helper)."""
         entries = hass.config_entries.async_entries(DOMAIN)
@@ -167,6 +215,7 @@ async def async_setup(hass: HomeAssistant, config):
     hass.services.async_register(DOMAIN, "set_variable", handle_set_variable)
     hass.services.async_register(DOMAIN, "set_params", handle_set_params)
     hass.services.async_register(DOMAIN, "set_charging_rules", handle_set_charging_rules)
+    hass.services.async_register(DOMAIN, "update_charging_rule", handle_update_charging_rule)
     hass.services.async_register(DOMAIN, "get_charging_rules", handle_get_charging_rules)
     hass.services.async_register(DOMAIN, "set_phase_mode", handle_set_phase_mode)
 

--- a/custom_components/powerbrain/__init__.py
+++ b/custom_components/powerbrain/__init__.py
@@ -30,7 +30,7 @@ from .powerbrain import Powerbrain
 _LOGGER = logging.getLogger(__name__)
 
 # List the platforms that you want to support.
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.NUMBER, Platform.SWITCH]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.NUMBER, Platform.SWITCH, Platform.SELECT]
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -92,6 +92,8 @@ async def async_setup(hass: HomeAssistant, config):
                     data["export_wh"] = call.data.get("export_energy") * 1000
                 if "is_va" in call.data:
                     data["is_va"] = call.data.get("is_va")
+                if "soc" in call.data:
+                    data["soc"] = call.data.get("soc")
                 hass.async_add_executor_job(brain.devices[dev_id].set_value, data)
 
     async def handle_set_variable(call):
@@ -146,12 +148,27 @@ async def async_setup(hass: HomeAssistant, config):
                     )
                     _LOGGER.info("Charging rules for %s: %s", dev_id, rules)
 
+    async def handle_set_phase_mode(call):
+        """Set phase mode for a specific EVSE (1 or 3 phases)."""
+        entries = hass.config_entries.async_entries(DOMAIN)
+        for entry in entries:
+            brain = hass.data[DOMAIN][entry.entry_id]
+            host = call.data.get("powerbrain_host", "")
+            if host == "" or host == brain.host:
+                dev_id = call.data.get("dev_id")
+                phases = call.data.get("phases", 3)
+                if dev_id in brain.devices:
+                    hass.async_add_executor_job(
+                        brain.devices[dev_id].set_phase_mode, phases
+                    )
+
     hass.services.async_register(DOMAIN, "enter_rfid", handle_enter_rfid)
     hass.services.async_register(DOMAIN, "set_meter", handle_set_meter)
     hass.services.async_register(DOMAIN, "set_variable", handle_set_variable)
     hass.services.async_register(DOMAIN, "set_params", handle_set_params)
     hass.services.async_register(DOMAIN, "set_charging_rules", handle_set_charging_rules)
     hass.services.async_register(DOMAIN, "get_charging_rules", handle_get_charging_rules)
+    hass.services.async_register(DOMAIN, "set_phase_mode", handle_set_phase_mode)
 
     return True
 

--- a/custom_components/powerbrain/powerbrain.py
+++ b/custom_components/powerbrain/powerbrain.py
@@ -13,6 +13,8 @@ API_OVERRIDE_FLAGS = "&flags="
 API_DEV_ID = "&dev_id="
 API_VAR_VAL = "&val="
 API_SET_METER = "/cnf?cmd=set_ajax_meter"
+API_GET_DEVICES_CFG = "/cnf?cmd=get_devices"
+API_SET_DEVICE_CFG = "/cnf?cmd=set_device"
 
 
 class Powerbrain:
@@ -92,43 +94,106 @@ class Powerbrain:
         response.raise_for_status()
 
     def get_charging_rules(self, dev_id: str) -> list:
-        """Get current charging rules for a device."""
-        dev_info = requests.get(self.host + API_GET_DEV_INFO, timeout=5).json()
+        """Get current charging rules for a device via get_devices (full config).
+
+        Returns list of rule dicts with cFos native format:
+            ctype   (int)   condition type (0=always/time, 1=solar surplus, ...)
+            atype   (int)   action type (0=set current, 10=pause)
+            aexpr   (int)   action value (current in mA, or 1 for pause)
+            days    (int)   weekday bitfield (bit0=Mon...bit6=Sun, 127=all)
+            time    (int)   start time in minutes since midnight
+            dur     (int)   duration in minutes
+            udur    (int)   undercut duration in seconds
+            flags   (int)   rule flags (16=normal, 18=end-on-finish)
+            ena     (bool)  rule enabled
+            cmt     (str)   comment/name for the rule
+            id      (int)   rule id (0 = auto-assigned)
+        """
+        response = requests.get(
+            self.host + API_GET_DEVICES_CFG,
+            timeout=5,
+            auth=(self.username, self.password),
+        )
+        response.raise_for_status()
+        devices_cfg = response.json()
         device = next(
-            (d for d in dev_info["devices"] if d["dev_id"] == dev_id), None
+            (d for d in devices_cfg if d["dev_id"] == dev_id), None
         )
         if device is None:
             raise ValueError(f"Device {dev_id} not found")
-        return device.get("charging_rules", [])
+        crule_set = device.get("crule_set") or {}
+        rule_set = crule_set.get("rule_set") or {}
+        return rule_set.get("", [])
 
     def set_charging_rules(self, dev_id: str, rules: list):
-        """Set charging rules for a specific device.
+        """Set charging rules for a specific device via set_device (full config).
 
-        Each rule is a dict with keys:
-            days    (int)   bitfield weekdays: bit0=Mon...bit6=Sun, 127=all days
-            mode    (int)   0=absolute current, 1=relative, 2=solar current,
-                            3=relative solar, 4=solar minus value, 5=solar surplus
-            current (int)   current in mA
-            enabled (bool)  True = rule active
-            time    (int)   minutes after midnight (for time-based rules)
-            dur     (int)   duration in minutes (for time-based rules)
-            udur    (int)   undercut duration in seconds
-            expr    (str)   expression string (for expression-based rules)
-            input   (str)   input string (for input-based rules)
-            price_level (int) price level (for cost-based rules)
-            solar   (int)   solar current in mA (for solar-based rules)
+        Reads current device config via get_devices, replaces crule_set.rule_set['']
+        with the provided rules list, and POSTs to cmd=set_device.
+
+        Each rule is a dict with cFos native format (see get_charging_rules).
+        Common rule templates:
+
+        Time-based charging rule (e.g. 22:00-07:00 at 16A every day):
+            {
+                'cmt': 'Overnight',
+                'days': 127,
+                'ctype': 0,       # 0 = no condition / time window
+                'atype': 0,       # 0 = set to value (current in mA)
+                'aexpr': 16000,   # 16A
+                'time': 1320,     # 22:00 = 22*60
+                'dur': 540,       # 9h = 540 min
+                'udur': 0,
+                'flags': 16,
+                'ena': True,
+                'id': 0,
+            }
+
+        Pause rule (e.g. pause for 5 min if solar < 3000W):
+            {
+                'cmt': 'Pause low solar',
+                'days': 127,
+                'ctype': 1,       # 1 = solar surplus condition
+                'atype': 10,      # 10 = pause
+                'aexpr': 1,
+                'cexpr': 3000,    # threshold in W
+                'udur': 300,
+                'flags': 18,
+                'ena': True,
+                'id': 0,
+            }
         """
-        payload = {
-            "devices": [
-                {
-                    "dev_id": dev_id,
-                    "charging_rules": rules,
-                }
-            ]
-        }
+        import json as _json
+        # Fetch full device config
+        response = requests.get(
+            self.host + API_GET_DEVICES_CFG,
+            timeout=5,
+            auth=(self.username, self.password),
+        )
+        response.raise_for_status()
+        devices_cfg = response.json()
+        device = next(
+            (d for d in devices_cfg if d["dev_id"] == dev_id), None
+        )
+        if device is None:
+            raise ValueError(f"Device {dev_id} not found")
+
+        # Ensure crule_set structure exists
+        if not device.get("crule_set"):
+            device["crule_set"] = {"rule_set": {"": []}, "selected_id": ""}
+        if "rule_set" not in device["crule_set"]:
+            device["crule_set"]["rule_set"] = {"": []}
+        if "" not in device["crule_set"]["rule_set"]:
+            device["crule_set"]["rule_set"][""] = []
+
+        device["crule_set"]["rule_set"][""] = rules
+
+        # POST updated device config (UI format: '{ "devices": [<dev>]}')
+        payload = '{ "devices": [' + _json.dumps(device) + ']}'
         response = requests.post(
-            self.host + API_SET_PARAMS,
-            json=payload,
+            self.host + API_SET_DEVICE_CFG,
+            data=payload,
+            headers={"Content-Type": "application/json"},
             timeout=5,
             auth=(self.username, self.password),
         )

--- a/custom_components/powerbrain/powerbrain.py
+++ b/custom_components/powerbrain/powerbrain.py
@@ -134,6 +134,22 @@ class Powerbrain:
         )
         response.raise_for_status()
 
+    def set_phase_mode(self, dev_id: str, phases: int):
+        """Set phase mode for an EVSE via Modbus HTTP API.
+
+        phases: 1 = single-phase (L1 only), 3 = three-phase.
+        Uses Modbus register 8044 (used_phases bitfield):
+          1 = bit0 = L1 only
+          7 = bits 0+1+2 = L1+L2+L3
+        """
+        value = 1 if phases == 1 else 7
+        response = requests.get(
+            f"{self.host}/cnf?cmd=modbus&device={dev_id.lower()}&write=8044&value={value}",
+            timeout=5,
+            auth=(self.username, self.password),
+        )
+        response.raise_for_status()
+
 
 class Device:
     """Device connected via Powerbrain."""
@@ -197,16 +213,46 @@ class Evse(Device):
         """Set charging rules for this EVSE. See Powerbrain.set_charging_rules for rule format."""
         self.brain.set_charging_rules(self.dev_id, rules)
 
+    def set_phase_mode(self, phases: int):
+        """Set phase mode: 1 = single-phase, 3 = three-phase."""
+        self.brain.set_phase_mode(self.dev_id, phases)
+
 
 class Meter(Device):
     """Energy meter device"""
 
     def set_value(self, data):
-        """send values of httpinput meter"""
+        """Send values to an HTTP input meter.
+
+        Supported keys (see cFos HTTP API docs):
+            power_va        (int)   Active power in W or VA
+            import_wh       (int)   Imported energy in Wh
+            export_wh       (int)   Exported energy in Wh
+            voltage         (list)  [v1, v2, v3] in V
+            current         (list)  [c1, c2, c3] in mA
+            is_va           (bool)  True if power is in VA
+            soc             (int)   State of charge 0-100% (storage meters only)
+        """
         response = requests.post(
             f"{self.brain.host}{API_SET_METER}{API_DEV_ID}{self.dev_id}",
             json=data,
             timeout=5,
             auth=(self.brain.username, self.brain.password),
+        )
+        response.raise_for_status()
+
+    def set_phase_mode(self, dev_id: str, phases: int):
+        """Set phase mode for an EVSE via Modbus HTTP API.
+
+        phases: 1 = single-phase (L1 only), 3 = three-phase.
+        Uses Modbus register 8044 (used_phases bitfield):
+          1 = bit0 = L1 only
+          7 = bits 0+1+2 = L1+L2+L3
+        """
+        value = 1 if phases == 1 else 7
+        response = requests.get(
+            f"{self.host}/cnf?cmd=modbus&device=evse&write=8044&value={value}",
+            timeout=5,
+            auth=(self.username, self.password),
         )
         response.raise_for_status()

--- a/custom_components/powerbrain/powerbrain.py
+++ b/custom_components/powerbrain/powerbrain.py
@@ -135,16 +135,22 @@ class Powerbrain:
         response.raise_for_status()
 
     def set_phase_mode(self, dev_id: str, phases: int):
-        """Set phase mode for an EVSE via Modbus HTTP API.
+        """Set phase mode for an EVSE.
 
         phases: 1 = single-phase (L1 only), 3 = three-phase.
-        Uses Modbus register 8044 (used_phases bitfield):
-          1 = bit0 = L1 only
-          7 = bits 0+1+2 = L1+L2+L3
+        Uses set_params with used_phases field (1=L1, 3=L1+L2+L3).
         """
-        value = 1 if phases == 1 else 7
-        response = requests.get(
-            f"{self.host}/cnf?cmd=modbus&device={dev_id.lower()}&write=8044&value={value}",
+        payload = {
+            "devices": [
+                {
+                    "dev_id": dev_id,
+                    "used_phases": phases,
+                }
+            ]
+        }
+        response = requests.post(
+            self.host + API_SET_PARAMS,
+            json=payload,
             timeout=5,
             auth=(self.username, self.password),
         )

--- a/custom_components/powerbrain/powerbrain.py
+++ b/custom_components/powerbrain/powerbrain.py
@@ -151,6 +151,19 @@ class Powerbrain:
         )
         response.raise_for_status()
 
+    def get_phase_mode(self) -> int:
+        """Read current phase mode from Modbus register 8044 (device=meter1).
+
+        Returns 1 for single-phase or 7 for three-phase.
+        """
+        response = requests.get(
+            f"{self.host}/cnf?cmd=modbus&device=meter1&read=8044",
+            timeout=5,
+            auth=(self.username, self.password),
+        )
+        response.raise_for_status()
+        return int(response.json())
+
 
 class Device:
     """Device connected via Powerbrain."""
@@ -217,6 +230,10 @@ class Evse(Device):
     def set_phase_mode(self, phases: int):
         """Set phase mode: 1 = single-phase, 3 = three-phase."""
         self.brain.set_phase_mode(self.dev_id, phases)
+
+    def get_phase_mode(self) -> int:
+        """Read current configured phase mode from register 8044. Returns 1 or 7."""
+        return self.brain.get_phase_mode()
 
 
 class Meter(Device):

--- a/custom_components/powerbrain/powerbrain.py
+++ b/custom_components/powerbrain/powerbrain.py
@@ -3,6 +3,7 @@ import requests
 
 API_GET_VALIDATE_AUTH = "/ui/en/sim.htm"
 API_GET_PARAMS = "/cnf?cmd=get_params"
+API_SET_PARAMS = "/cnf?cmd=set_params"
 API_GET_DEV_INFO = "/cnf?cmd=get_dev_info"
 API_GET_ENTER_RFID = "/cnf?cmd=enter_rfid&rfid="
 API_GET_SET_VAR = "/cnf?cmd=set_cm_vars&name="
@@ -69,12 +70,69 @@ class Powerbrain:
         requests.get(self.host + API_GET_ENTER_RFID + rfid + dev_id, timeout=5)
 
     def set_variable(self, name, value):
-        """Set value of a charging manager variable"""
+        """Set value of a charging manager variable."""
         requests.get(
             f"{self.host}{API_GET_SET_VAR}{name}{API_VAR_VAL}{value}",
             timeout=5,
             auth=(self.username, self.password),
         )
+
+    def set_params(self, params: dict):
+        """Set global Charging Manager parameters via POST.
+
+        Supported keys include: min_pause_time, disable_policy, max_total_current,
+        reserve_current, lb_enabled, feed_in_tariff, price_model, surplus_expr, etc.
+        """
+        response = requests.post(
+            self.host + API_SET_PARAMS,
+            json=params,
+            timeout=5,
+            auth=(self.username, self.password),
+        )
+        response.raise_for_status()
+
+    def get_charging_rules(self, dev_id: str) -> list:
+        """Get current charging rules for a device."""
+        dev_info = requests.get(self.host + API_GET_DEV_INFO, timeout=5).json()
+        device = next(
+            (d for d in dev_info["devices"] if d["dev_id"] == dev_id), None
+        )
+        if device is None:
+            raise ValueError(f"Device {dev_id} not found")
+        return device.get("charging_rules", [])
+
+    def set_charging_rules(self, dev_id: str, rules: list):
+        """Set charging rules for a specific device.
+
+        Each rule is a dict with keys:
+            days    (int)   bitfield weekdays: bit0=Mon...bit6=Sun, 127=all days
+            mode    (int)   0=absolute current, 1=relative, 2=solar current,
+                            3=relative solar, 4=solar minus value, 5=solar surplus
+            current (int)   current in mA
+            enabled (bool)  True = rule active
+            time    (int)   minutes after midnight (for time-based rules)
+            dur     (int)   duration in minutes (for time-based rules)
+            udur    (int)   undercut duration in seconds
+            expr    (str)   expression string (for expression-based rules)
+            input   (str)   input string (for input-based rules)
+            price_level (int) price level (for cost-based rules)
+            solar   (int)   solar current in mA (for solar-based rules)
+        """
+        payload = {
+            "devices": [
+                {
+                    "dev_id": dev_id,
+                    "charging_rules": rules,
+                }
+            ]
+        }
+        response = requests.post(
+            self.host + API_SET_PARAMS,
+            json=payload,
+            timeout=5,
+            auth=(self.username, self.password),
+        )
+        response.raise_for_status()
 
 
 class Device:
@@ -130,6 +188,14 @@ class Evse(Device):
             auth=(self.brain.username, self.brain.password),
         )
         response.raise_for_status()
+
+    def get_charging_rules(self) -> list:
+        """Get current charging rules for this EVSE."""
+        return self.brain.get_charging_rules(self.dev_id)
+
+    def set_charging_rules(self, rules: list):
+        """Set charging rules for this EVSE. See Powerbrain.set_charging_rules for rule format."""
+        self.brain.set_charging_rules(self.dev_id, rules)
 
 
 class Meter(Device):

--- a/custom_components/powerbrain/powerbrain.py
+++ b/custom_components/powerbrain/powerbrain.py
@@ -137,20 +137,15 @@ class Powerbrain:
     def set_phase_mode(self, dev_id: str, phases: int):
         """Set phase mode for an EVSE.
 
-        phases: 1 = single-phase (L1 only), 3 = three-phase.
-        Uses set_params with used_phases field (1=L1, 3=L1+L2+L3).
+        phases: 1 = single-phase (L1 only), 3 = three-phase (L1+L2+L3).
+        Uses Modbus register 8044 via device=meter1 (built-in EVSE Modbus alias).
+        Value: 1 = L1 only, 7 = L1+L2+L3.
+        Note: used_phases in get_dev_info reflects active phases during charging;
+        the register value is the configured target applied on next session start.
         """
-        payload = {
-            "devices": [
-                {
-                    "dev_id": dev_id,
-                    "used_phases": phases,
-                }
-            ]
-        }
-        response = requests.post(
-            self.host + API_SET_PARAMS,
-            json=payload,
+        value = 1 if phases == 1 else 7
+        response = requests.get(
+            f"{self.host}/cnf?cmd=modbus&device=meter1&write=8044&value={value}",
             timeout=5,
             auth=(self.username, self.password),
         )
@@ -247,18 +242,4 @@ class Meter(Device):
         )
         response.raise_for_status()
 
-    def set_phase_mode(self, dev_id: str, phases: int):
-        """Set phase mode for an EVSE via Modbus HTTP API.
 
-        phases: 1 = single-phase (L1 only), 3 = three-phase.
-        Uses Modbus register 8044 (used_phases bitfield):
-          1 = bit0 = L1 only
-          7 = bits 0+1+2 = L1+L2+L3
-        """
-        value = 1 if phases == 1 else 7
-        response = requests.get(
-            f"{self.host}/cnf?cmd=modbus&device=evse&write=8044&value={value}",
-            timeout=5,
-            auth=(self.username, self.password),
-        )
-        response.raise_for_status()

--- a/custom_components/powerbrain/select.py
+++ b/custom_components/powerbrain/select.py
@@ -16,13 +16,10 @@ from .powerbrain import Evse
 from .powerbrain import Powerbrain
 
 PHASE_OPTIONS = ["1 phase", "3 phases"]
-PHASE_TO_INT = {"1 phase": 1, "3 phases": 3}
-# used_phases: 1 = L1 only, 3 = L1+L2+L3; 0 = auto
-PHASE_BITS_TO_OPTION = {
-    0: "3 phases",
+PHASE_TO_INT = {"1 phase": 1, "3 phases": 7}
+# Register 8044: 1 = L1 only (1 phase), 7 = L1+L2+L3 (3 phases)
+PHASE_REG_TO_OPTION = {
     1: "1 phase",
-    2: "3 phases",
-    3: "3 phases",
     7: "3 phases",
 }
 
@@ -69,15 +66,31 @@ class EvsePhaseSelectEntity(CoordinatorEntity, SelectEntity):
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        bits = self.device.attributes.get("phases", 0)
-        self._attr_current_option = PHASE_BITS_TO_OPTION.get(bits, "3 phases")
+        # Read register 8044 via Modbus — this is the configured phase mode, not the active one
+        # We cache the last known value to avoid blocking calls in the callback
+        if hasattr(self, "_phase_reg_value"):
+            self._attr_current_option = PHASE_REG_TO_OPTION.get(
+                self._phase_reg_value, "3 phases"
+            )
         self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Read initial phase mode from register 8044 when entity is added."""
+        await super().async_added_to_hass()
+        self._phase_reg_value = await self.hass.async_add_executor_job(
+            self.device.get_phase_mode
+        )
+        self._attr_current_option = PHASE_REG_TO_OPTION.get(
+            self._phase_reg_value, "3 phases"
+        )
 
     async def async_select_option(self, option: str) -> None:
         """Change phase mode."""
-        phases = PHASE_TO_INT.get(option, 3)
+        phases = PHASE_TO_INT.get(option, 7)
         await self.hass.async_add_executor_job(self.device.set_phase_mode, phases)
-        await self.coordinator.async_request_refresh()
+        self._phase_reg_value = phases
+        self._attr_current_option = option
+        self.async_write_ha_state()
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/powerbrain/select.py
+++ b/custom_components/powerbrain/select.py
@@ -17,10 +17,12 @@ from .powerbrain import Powerbrain
 
 PHASE_OPTIONS = ["1 phase", "3 phases"]
 PHASE_TO_INT = {"1 phase": 1, "3 phases": 3}
-# used_phases bitfield: 1 = L1 only, 7 = L1+L2+L3; 0 = auto-detect
+# used_phases: 1 = L1 only, 3 = L1+L2+L3; 0 = auto
 PHASE_BITS_TO_OPTION = {
-    0: "3 phases",  # auto / 3-phase default
+    0: "3 phases",
     1: "1 phase",
+    2: "3 phases",
+    3: "3 phases",
     7: "3 phases",
 }
 

--- a/custom_components/powerbrain/select.py
+++ b/custom_components/powerbrain/select.py
@@ -1,0 +1,83 @@
+"""Select platform for cFos Powerbrain — phase mode selection."""
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .__init__ import get_entity_deviceinfo
+from .__init__ import PowerbrainUpdateCoordinator
+from .const import DOMAIN
+from .powerbrain import Evse
+from .powerbrain import Powerbrain
+
+PHASE_OPTIONS = ["1 phase", "3 phases"]
+PHASE_TO_INT = {"1 phase": 1, "3 phases": 3}
+# used_phases bitfield: 1 = L1 only, 7 = L1+L2+L3; 0 = auto-detect
+PHASE_BITS_TO_OPTION = {
+    0: "3 phases",  # auto / 3-phase default
+    1: "1 phase",
+    7: "3 phases",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Create the select entities for powerbrain integration."""
+    brain: Powerbrain = hass.data[DOMAIN][entry.entry_id]
+
+    entities = []
+    for device in brain.devices.values():
+        if device.attributes["is_evse"]:
+            entities.append(
+                EvsePhaseSelectEntity(
+                    hass.data[DOMAIN][entry.entry_id + "_coordinator"],
+                    device,
+                    "Phase Mode",
+                )
+            )
+    async_add_entities(entities)
+
+
+class EvsePhaseSelectEntity(CoordinatorEntity, SelectEntity):
+    """Select entity for EVSE phase mode (1-phase / 3-phase)."""
+
+    def __init__(
+        self,
+        coordinator: PowerbrainUpdateCoordinator,
+        device: Evse,
+        name: str,
+    ) -> None:
+        """Initialize phase select entity."""
+        super().__init__(coordinator)
+        self.device = device
+        self._attr_has_entity_name = True
+        self._attr_unique_id = (
+            f"{coordinator.brain.attributes['vsn']['serialno']}"
+            f"_{self.device.dev_id}_{name}"
+        )
+        self._attr_name = name
+        self._attr_options = PHASE_OPTIONS
+        self._attr_icon = "mdi:sine-wave"
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        bits = self.device.attributes.get("phases", 0)
+        self._attr_current_option = PHASE_BITS_TO_OPTION.get(bits, "3 phases")
+        self.async_write_ha_state()
+
+    async def async_select_option(self, option: str) -> None:
+        """Change phase mode."""
+        phases = PHASE_TO_INT.get(option, 3)
+        await self.hass.async_add_executor_job(self.device.set_phase_mode, phases)
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Information of the parent device."""
+        return get_entity_deviceinfo(self.device)

--- a/custom_components/powerbrain/sensor.py
+++ b/custom_components/powerbrain/sensor.py
@@ -21,12 +21,20 @@ from .powerbrain import Powerbrain
 
 _LOGGER = logging.getLogger(__name__)
 
+PAUSE_REASON_MAP = {
+    0: "None",
+    1: "Current limit",
+    2: "Charging rules",
+    3: "Manual pause",
+    4: "Phase switch",
+    5: "Error",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Config entry example."""
-    # assuming API object stored here by __init__.py
     brain: Powerbrain = hass.data[DOMAIN][entry.entry_id]
 
     entities = []
@@ -60,12 +68,14 @@ class PowerbrainDeviceSensor(CoordinatorEntity, SensorEntity):
         deviceclass: str = None,
         stateclass: str = None,
         state_modifier: Any = None,
+        nested_path: list = None,
     ) -> None:
         """Initialize sensor attributes."""
         super().__init__(coordinator)
         self.device = device
         self.attribute = attr
         self.state_modifier = state_modifier
+        self.nested_path = nested_path  # e.g. ["evse", "cp_state"]
         self._attr_has_entity_name = True
         self._attr_unique_id = f"{coordinator.brain.attributes['vsn']['serialno']}_{self.device.dev_id}_{name}"
         self._attr_name = name
@@ -73,17 +83,32 @@ class PowerbrainDeviceSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_class = deviceclass
         self._attr_state_class = stateclass
 
+    def _get_raw_value(self):
+        """Get raw value from device attributes, supporting nested paths."""
+        if self.nested_path:
+            value = self.device.attributes
+            for key in self.nested_path:
+                if isinstance(value, dict) and key in value:
+                    value = value[key]
+                else:
+                    return None
+            return value
+        return self.device.attributes.get(self.attribute)
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        raw = self._get_raw_value()
+        if raw is None:
+            return
 
         new_value = 0
         if self.state_modifier is None:
-            new_value = self.device.attributes[self.attribute]
+            new_value = raw
         elif isinstance(self.state_modifier, types.LambdaType):
-            new_value = self.state_modifier(self.device.attributes[self.attribute])
+            new_value = self.state_modifier(raw)
         else:
-            new_value = self.device.attributes[self.attribute] * self.state_modifier
+            new_value = raw * self.state_modifier
 
         if (
             self._attr_native_value is None
@@ -109,106 +134,56 @@ def create_meter_entities(coordinator: PowerbrainUpdateCoordinator, device: Devi
             power_unit = "VA"
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "power_w" if coordinator.brain.version >= 1.2 else "power",
-            "Power",
-            power_unit,
-            SensorDeviceClass.POWER,
-            SensorStateClass.MEASUREMENT,
+            coordinator, device, "power_w" if coordinator.brain.version >= 1.2 else "power",
+            "Power", power_unit, SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "import",
-            "Import",
-            "kWh",
-            SensorDeviceClass.ENERGY,
-            SensorStateClass.TOTAL_INCREASING,
-            0.001,
+            coordinator, device, "import", "Import", "kWh",
+            SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING, 0.001,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "export",
-            "Export",
-            "kWh",
-            SensorDeviceClass.ENERGY,
-            SensorStateClass.TOTAL_INCREASING,
-            0.001,
+            coordinator, device, "export", "Export", "kWh",
+            SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING, 0.001,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "current_l1",
-            "Current L1",
-            "A",
-            SensorDeviceClass.CURRENT,
-            SensorStateClass.MEASUREMENT,
-            0.001,
+            coordinator, device, "current_l1", "Current L1", "A",
+            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, 0.001,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "current_l2",
-            "Current L2",
-            "A",
-            SensorDeviceClass.CURRENT,
-            SensorStateClass.MEASUREMENT,
-            0.001,
+            coordinator, device, "current_l2", "Current L2", "A",
+            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, 0.001,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "current_l3",
-            "Current L3",
-            "A",
-            SensorDeviceClass.CURRENT,
-            SensorStateClass.MEASUREMENT,
-            0.001,
+            coordinator, device, "current_l3", "Current L3", "A",
+            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, 0.001,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "voltage_l1",
-            "Voltage L1",
-            "V",
-            SensorDeviceClass.VOLTAGE,
-            SensorStateClass.MEASUREMENT,
+            coordinator, device, "voltage_l1", "Voltage L1", "V",
+            SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "voltage_l2",
-            "Voltage L2",
-            "V",
-            SensorDeviceClass.VOLTAGE,
-            SensorStateClass.MEASUREMENT,
+            coordinator, device, "voltage_l2", "Voltage L2", "V",
+            SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "voltage_l3",
-            "Voltage L3",
-            "V",
-            SensorDeviceClass.VOLTAGE,
-            SensorStateClass.MEASUREMENT,
+            coordinator, device, "voltage_l3", "Voltage L3", "V",
+            SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT,
         )
     )
     return ret
@@ -218,35 +193,24 @@ def create_evse_entities(coordinator: PowerbrainUpdateCoordinator, device: Devic
     """Create the entities for an evse device."""
     ret = []
 
+    # ── Existing sensors ──────────────────────────────────────────────────────
+
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
+            coordinator, device,
             "power_w" if coordinator.brain.version >= 1.2 else "cur_charging_power",
-            "Charging Power",
-            "W",
-            SensorDeviceClass.POWER,
-            SensorStateClass.MEASUREMENT,
+            "Charging Power", "W", SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "total_energy",
-            "Total Charging Energy",
-            "kWh",
-            SensorDeviceClass.ENERGY,
-            SensorStateClass.TOTAL_INCREASING,
-            0.001,
+            coordinator, device, "total_energy", "Total Charging Energy", "kWh",
+            SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING, 0.001,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "state",
-            "State",
+            coordinator, device, "state", "State",
             state_modifier=lambda s: {
                 1: "1: Standby",
                 2: "2: Car connected",
@@ -254,43 +218,92 @@ def create_evse_entities(coordinator: PowerbrainUpdateCoordinator, device: Devic
                 4: "4: Charging/vent",
                 5: "5: Error",
                 6: "6: Offline",
-            }[s],
+            }.get(s, f"Unknown ({s})"),
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "current_l1",
-            "Current L1",
-            "A",
-            SensorDeviceClass.CURRENT,
-            SensorStateClass.MEASUREMENT,
-            0.001,
+            coordinator, device, "current_l1", "Current L1", "A",
+            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, 0.001,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "current_l2",
-            "Current L2",
-            "A",
-            SensorDeviceClass.CURRENT,
-            SensorStateClass.MEASUREMENT,
-            0.001,
+            coordinator, device, "current_l2", "Current L2", "A",
+            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, 0.001,
         )
     )
     ret.append(
         PowerbrainDeviceSensor(
-            coordinator,
-            device,
-            "current_l3",
-            "Current L3",
-            "A",
-            SensorDeviceClass.CURRENT,
-            SensorStateClass.MEASUREMENT,
-            0.001,
+            coordinator, device, "current_l3", "Current L3", "A",
+            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, 0.001,
         )
     )
+
+    # ── New sensors ───────────────────────────────────────────────────────────
+
+    # Session energy (Wh → kWh). Resets each charging session.
+    ret.append(
+        PowerbrainDeviceSensor(
+            coordinator, device, "ta_en", "Session Energy", "kWh",
+            SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING, 0.001,
+        )
+    )
+
+    # Last commanded charging current (mA → A)
+    ret.append(
+        PowerbrainDeviceSensor(
+            coordinator, device, "last_set_charging_cur", "Last Set Charging Current", "A",
+            SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT, 0.001,
+        )
+    )
+
+    # Number of phases currently in use
+    ret.append(
+        PowerbrainDeviceSensor(
+            coordinator, device, "used_phases", "Used Phases",
+            None, None, SensorStateClass.MEASUREMENT,
+        )
+    )
+
+    # Pause reason (human-readable)
+    ret.append(
+        PowerbrainDeviceSensor(
+            coordinator, device, "pause_reason", "Pause Reason",
+            state_modifier=lambda r: PAUSE_REASON_MAP.get(r, f"Unknown ({r})"),
+        )
+    )
+
+    # Pause remaining time in seconds (0 when not paused)
+    ret.append(
+        PowerbrainDeviceSensor(
+            coordinator, device, "pause_time", "Pause Time Remaining", "s",
+            SensorDeviceClass.DURATION, SensorStateClass.MEASUREMENT,
+        )
+    )
+
+    # CP (Control Pilot) state — from nested evse object
+    ret.append(
+        PowerbrainDeviceSensor(
+            coordinator, device, "cp_state", "CP State",
+            nested_path=["evse", "cp_state"],
+        )
+    )
+
+    # PP (Proximity Pilot) state — cable detection
+    ret.append(
+        PowerbrainDeviceSensor(
+            coordinator, device, "pp_state", "PP State",
+            nested_path=["evse", "pp_state"],
+        )
+    )
+
+    # Total cumulative charging duration in seconds
+    ret.append(
+        PowerbrainDeviceSensor(
+            coordinator, device, "charging_dur", "Total Charging Duration", "s",
+            SensorDeviceClass.DURATION, SensorStateClass.TOTAL_INCREASING,
+        )
+    )
+
     return ret

--- a/custom_components/powerbrain/sensor.py
+++ b/custom_components/powerbrain/sensor.py
@@ -246,7 +246,7 @@ def create_evse_entities(coordinator: PowerbrainUpdateCoordinator, device: Devic
     ret.append(
         PowerbrainDeviceSensor(
             coordinator, device, "ta_en", "Session Energy", "kWh",
-            SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING, 0.001,
+            SensorDeviceClass.ENERGY, SensorStateClass.MEASUREMENT, 0.001,
         )
     )
 

--- a/custom_components/powerbrain/services.yaml
+++ b/custom_components/powerbrain/services.yaml
@@ -108,3 +108,102 @@ set_variable:
       advanced: true
       required: false
       example: "192.168.1.20"
+
+set_params:
+  name: Set Charging Manager Parameters
+  description: >
+    Set global cFos Charging Manager parameters (e.g. min_pause_time,
+    disable_policy, max_total_current, lb_enabled, feed_in_tariff, surplus_expr).
+    Only include the keys you want to change.
+  fields:
+    min_pause_time:
+      name: Minimum Pause Time
+      description: Minimum pause duration between charging sessions (seconds)
+      required: false
+      example: 300
+    disable_policy:
+      name: Disable Policy
+      description: >
+        Policy when device is disabled.
+        0 = disable EVSE, 1 = use minimum charging current, -1 = remove limit (free charging)
+      required: false
+      example: 1
+    max_total_current:
+      name: Max Total Current
+      description: Total installed power limit in mA
+      required: false
+      example: 32000
+    lb_enabled:
+      name: Load Balancing Enabled
+      description: Enable or disable load balancing
+      required: false
+      example: true
+    feed_in_tariff:
+      name: Feed-in Tariff
+      description: Feed-in tariff in currency/kWh (used for solar surplus logic)
+      required: false
+      example: 0.04
+    surplus_expr:
+      name: Surplus Expression
+      description: Expression to calculate surplus power
+      required: false
+      example: ""
+    powerbrain_host:
+      name: Powerbrain instance host
+      description: Specify host address if more than one Powerbrain instance is configured (optional)
+      advanced: true
+      required: false
+      example: "http://192.168.1.20"
+
+set_charging_rules:
+  name: Set EVSE Charging Rules
+  description: >
+    Set (replace) the charging rules for a specific EVSE.
+    Rules are evaluated in order; all existing rules are replaced.
+    Note: the cFos API marks charging_rules as work in progress and may change.
+  fields:
+    dev_id:
+      name: Device Id
+      description: EVSE device ID (e.g. E1)
+      required: true
+      example: "E1"
+    rules:
+      name: Charging Rules
+      description: >
+        Array of rule objects. Each rule may contain:
+        days (int, weekday bitfield: bit0=Mon...bit6=Sun, 127=all),
+        mode (int, 0=absolute current, 1=relative, 2=solar current, 5=solar surplus),
+        current (int, mA),
+        enabled (bool),
+        time (int, minutes after midnight),
+        dur (int, duration in minutes),
+        udur (int, undercut duration in seconds),
+        expr (str, expression),
+        price_level (int),
+        solar (int, solar current in mA).
+      required: true
+      example: '[{"days": 127, "mode": 0, "current": 32000, "enabled": true, "time": 1335, "dur": 45}]'
+    powerbrain_host:
+      name: Powerbrain instance host
+      description: Specify host address if more than one Powerbrain instance is configured (optional)
+      advanced: true
+      required: false
+      example: "http://192.168.1.20"
+
+get_charging_rules:
+  name: Get EVSE Charging Rules
+  description: >
+    Retrieve and log the current charging rules for a specific EVSE.
+    Rules are written to the Home Assistant log at INFO level.
+  fields:
+    dev_id:
+      name: Device Id
+      description: EVSE device ID (e.g. E1)
+      required: true
+      example: "E1"
+    powerbrain_host:
+      name: Powerbrain instance host
+      description: Specify host address if more than one Powerbrain instance is configured (optional)
+      advanced: true
+      required: false
+      example: "http://192.168.1.20"

--- a/custom_components/powerbrain/services.yaml
+++ b/custom_components/powerbrain/services.yaml
@@ -165,7 +165,7 @@ set_charging_rules:
   description: >
     Set (replace) the charging rules for a specific EVSE.
     Rules are evaluated in order; all existing rules are replaced.
-    Note: the cFos API marks charging_rules as work in progress and may change.
+    Uses the native cFos set_device API with crule_set format.
   fields:
     dev_id:
       name: Device Id
@@ -175,19 +175,20 @@ set_charging_rules:
     rules:
       name: Charging Rules
       description: >
-        Array of rule objects. Each rule may contain:
-        days (int, weekday bitfield: bit0=Mon...bit6=Sun, 127=all),
-        mode (int, 0=absolute current, 1=relative, 2=solar current, 5=solar surplus),
-        current (int, mA),
-        enabled (bool),
-        time (int, minutes after midnight),
+        Array of rule objects in cFos native format. Each rule may contain:
+        cmt (str, comment/label),
+        days (int, weekday bitfield: bit0=Mon...bit6=Sun, 127=all days),
+        ctype (int, condition type: 0=none/time, 1=solar surplus, ...),
+        atype (int, action type: 0=set current in mA, 10=pause),
+        aexpr (int, action value: current in mA for atype=0, 1 for atype=10),
+        time (int, start time in minutes since midnight),
         dur (int, duration in minutes),
         udur (int, undercut duration in seconds),
-        expr (str, expression),
-        price_level (int),
-        solar (int, solar current in mA).
+        flags (int, 16=normal, 18=end-on-finish),
+        ena (bool, rule enabled),
+        id (int, 0=auto-assign).
       required: true
-      example: '[{"days": 127, "mode": 0, "current": 32000, "enabled": true, "time": 1335, "dur": 45}]'
+      example: '[{"cmt": "Overnight", "days": 127, "ctype": 0, "atype": 0, "aexpr": 16000, "time": 1320, "dur": 540, "udur": 0, "flags": 16, "ena": true, "id": 0}]'
     powerbrain_host:
       name: Powerbrain instance host
       description: Specify host address if more than one Powerbrain instance is configured (optional)

--- a/custom_components/powerbrain/services.yaml
+++ b/custom_components/powerbrain/services.yaml
@@ -196,6 +196,56 @@ set_charging_rules:
       required: false
       example: "http://192.168.1.20"
 
+update_charging_rule:
+  name: Update EVSE Charging Rule by Label
+  description: >
+    Find a charging rule by its cmt label and update specific fields only.
+    All other rules remain unchanged. If no rule with that label exists, a new one is appended.
+    This is the recommended way to update a single rule (e.g. change start time/duration)
+    without affecting other rules like solar-pause rules.
+  fields:
+    dev_id:
+      name: Device Id
+      description: EVSE device ID (e.g. E1)
+      required: true
+      example: "E1"
+    cmt:
+      name: Rule Label
+      description: The cmt (comment/label) of the rule to update
+      required: true
+      example: "EV Carregamento Nocturno"
+    time:
+      name: Start Time (minutes)
+      description: New start time in minutes since midnight (e.g. 1320 = 22:00)
+      required: false
+      example: 1320
+    dur:
+      name: Duration (minutes)
+      description: New duration in minutes
+      required: false
+      example: 180
+    aexpr:
+      name: Current (mA)
+      description: Charging current in mA (for atype=0 rules)
+      required: false
+      example: 16000
+    ena:
+      name: Enabled
+      description: Enable or disable the rule
+      required: false
+      example: true
+    days:
+      name: Days
+      description: Weekday bitfield (bit0=Mon...bit6=Sun, 127=all days)
+      required: false
+      example: 127
+    powerbrain_host:
+      name: Powerbrain instance host
+      description: Specify host address if more than one Powerbrain instance is configured (optional)
+      advanced: true
+      required: false
+      example: "http://192.168.1.20"
+
 get_charging_rules:
   name: Get EVSE Charging Rules
   description: >

--- a/custom_components/powerbrain/services.yaml
+++ b/custom_components/powerbrain/services.yaml
@@ -88,6 +88,11 @@ set_meter:
       advanced: true
       required: false
       example: "192.168.1.20"
+    soc:
+      name: State of Charge
+      description: Battery state of charge 0-100% (for storage meters only)
+      required: false
+      example: 75
 set_variable:
   name: Set Variable
   description: Sets value of a charging manager variable
@@ -201,6 +206,29 @@ get_charging_rules:
       description: EVSE device ID (e.g. E1)
       required: true
       example: "E1"
+    powerbrain_host:
+      name: Powerbrain instance host
+      description: Specify host address if more than one Powerbrain instance is configured (optional)
+      advanced: true
+      required: false
+      example: "http://192.168.1.20"
+
+set_phase_mode:
+  name: Set Phase Mode
+  description: >
+    Set the charging phase mode for an EVSE (1-phase or 3-phase).
+    Uses Modbus register 8044 to set the used_phases bitfield.
+  fields:
+    dev_id:
+      name: Device Id
+      description: EVSE device ID (e.g. E1)
+      required: true
+      example: "E1"
+    phases:
+      name: Phases
+      description: "Number of phases: 1 = single-phase (L1 only), 3 = three-phase (L1+L2+L3)"
+      required: true
+      example: 1
     powerbrain_host:
       name: Powerbrain instance host
       description: Specify host address if more than one Powerbrain instance is configured (optional)


### PR DESCRIPTION
## Summary

This PR adds several quality-of-life improvements to the cFos Powerbrain integration:

1. **8 new sensors** — expose additional EVSE telemetry fields already available in the cFos API
2. **Phase Mode select entity** — read/write the configured phase count (1-phase / 3-phase) via Modbus register
3. **5 new HA services** — programmatic control of charging rules, phase mode, and device parameters
4. **Bug fixes** — correct API endpoints for charging rules persistence

All changes have been running in production on a real cFos Powerbrain wallbox (firmware 2.12.6) for several days.

---

## New Sensors

All new sensors use existing fields from `GET /cnf?cmd=get_dev_info` — no new API calls required.

| Entity | Field | Unit | Description |
|--------|-------|------|-------------|
| `sensor.wallbox_session_energy` | `evse.ta_en` | kWh | Energy delivered in current/last session |
| `sensor.wallbox_last_set_charging_current` | `evse.set_current` | A | Last commanded charging current |
| `sensor.wallbox_used_phases` | `evse.phases` | — | Phases actively used during charging (1 or 3) |
| `sensor.wallbox_pause_reason` | `evse.pause_reason` | — | Why charging is currently paused (rule, user, solar…) |
| `sensor.wallbox_pause_time_remaining` | `evse.pause_time` | s | Seconds until pause expires (undercut duration) |
| `sensor.wallbox_cp_state` | `evse.cp_state` | — | IEC 61851 Control Pilot state (A/B/C/D/E/F) |
| `sensor.wallbox_pp_state` | `evse.pp_state` | — | Proximity Pilot state (cable capacity detection) |
| `sensor.wallbox_total_charging_duration` | `evse.charging_duration` | s | Total charging duration for current session |

---

## New Select Entity: Phase Mode

**Entity:** `select.wallbox_phase_mode`  
**Options:** `1 phase`, `3 phases`

Reads and writes the **configured** phase mode via Modbus register 8044.

> ⚠️ The `phases` / `used_phases` field in `get_dev_info` is a **read-only runtime value** that resets to 0 when the car is not charging. Register 8044 holds the **persistent configured value** and is the correct way to read/write the phase mode.

**Register mapping:**
| Register 8044 value | Meaning |
|---|---|
| `1` | Single-phase (L1 only) |
| `7` | Three-phase (L1 + L2 + L3) |

**Implementation notes:**
- On entity load (`async_added_to_hass`), reads register 8044 via `GET /cnf?cmd=modbus&device=meter1&read=8044`
- On select change, writes register 8044 and caches the value locally
- `_handle_coordinator_update` uses cached value to avoid blocking calls in the update callback

This addresses the feature request in issues [#71](https://github.com/mb-software/homeassistant-powerbrain/issues/71) and [#83](https://github.com/mb-software/homeassistant-powerbrain/issues/83).

---

## New Services

### `powerbrain.update_charging_rule` *(recommended for automations)*

Patch a single charging rule identified by its `cmt` label. Only the supplied fields are updated; **all other rules remain untouched**.

If no rule with the given label exists, a new rule is appended automatically.

| Field | Required | Description |
|-------|----------|-------------|
| `dev_id` | ✅ | EVSE device ID (e.g. `E1`) |
| `cmt` | ✅ | Label of the rule to update |
| `time` | — | Start time in minutes since midnight |
| `dur` | — | Duration in minutes |
| `aexpr` | — | Charging current in mA (for `atype=0`) |
| `ena` | — | Enable (`true`) or disable (`false`) the rule |
| `days` | — | Weekday bitfield (bit0=Mon…bit6=Sun, `127`=all) |

Example — enable EV overnight rule at 23:00 for 2h:
```yaml
service: powerbrain.update_charging_rule
data:
  dev_id: E1
  cmt: "EV overnight"
  time: 1380
  dur: 120
  ena: true
```

---

### `powerbrain.set_charging_rules`

Replace **all** charging rules for an EVSE. Existing rules are overwritten.

Uses the correct cFos API: `GET /cnf?cmd=get_devices` (read) + `POST /cnf?cmd=set_device` (write). See bug fix section below for why this matters.

| Field | Required | Description |
|-------|----------|-------------|
| `dev_id` | ✅ | EVSE device ID |
| `rules` | ✅ | Array of rule objects |

**Rule object fields** (cFos native format):

| Field | Type | Description |
|-------|------|-------------|
| `ctype` | int | Condition type: `0`=time window, `1`=solar surplus |
| `atype` | int | Action type: `0`=set current in mA, `10`=pause |
| `aexpr` | int | Current in mA (atype=0) or `1` (atype=10) |
| `time` | int | Start time in minutes since midnight |
| `dur` | int | Duration in minutes |
| `days` | int | Weekday bitfield (`127`=all days) |
| `udur` | int | Undercut duration in seconds |
| `flags` | int | `16`=normal, `18`=end-on-finish |
| `ena` | bool | Rule enabled |
| `cmt` | str | Comment/label |

---

### `powerbrain.get_charging_rules`

Read the current charging rules from an EVSE device. Returns the rules array in the HA response.

| Field | Required | Description |
|-------|----------|-------------|
| `dev_id` | ✅ | EVSE device ID |

---

### `powerbrain.set_phase_mode`

Set the phase mode via Modbus register 8044.

| Field | Required | Description |
|-------|----------|-------------|
| `dev_id` | ✅ | EVSE device ID |
| `phases` | ✅ | `1` (single-phase) or `3` (three-phase) |

---

### `powerbrain.set_params`

Set global cFos Powerbrain parameters via `POST /cnf?cmd=set_params`.

| Field | Required | Description |
|-------|----------|-------------|
| `params` | ✅ | Object with parameter key/value pairs |

---

## Bug Fix: Charging Rules API

**Problem:** The previous `set_charging_rules` implementation used `POST /cnf?cmd=set_params` with a `charging_rules` field. This endpoint returns `"ok"` but the rules are **not persisted** — they disappear on the next page reload.

**Root cause discovered:** By inspecting the cFos UI JavaScript (`dlg_helper.js` + `index.htm`), the UI uses two different endpoints:
- **Read:** `GET /cnf?cmd=get_devices` → returns full device config including `crule_set.rule_set['']` array
- **Write:** `POST /cnf?cmd=set_device` → expects `{ "devices": [<full_device_json>] }` (same format as read)

**Fix:** `get_charging_rules()` now calls `get_devices` and reads `crule_set.rule_set['']`. `set_charging_rules()` fetches the full device config via `get_devices`, replaces the rules array, then POSTs via `set_device`.

---

## Testing

Tested on:
- **Hardware:** cFos Powerbrain wallbox, firmware 2.12.6, serial W00-03C2
- **Home Assistant:** 2026.3.1
- **Python:** 3.13 (HA container)

Tests performed:
- `get_charging_rules` — returns correct rule array ✅
- `set_charging_rules` — rules persist after page reload ✅
- `update_charging_rule` — patches target rule, leaves others untouched ✅
- `select.wallbox_phase_mode` — shows `1 phase` correctly after entity load ✅
- `set_phase_mode` — writes register 8044, confirmed via direct Modbus read ✅
- All 8 new sensors — values match cFos web UI ✅

---

## Files Changed

| File | Change |
|------|--------|
| `custom_components/powerbrain/sensor.py` | +8 new sensors |
| `custom_components/powerbrain/select.py` | **New file** — Phase Mode select entity |
| `custom_components/powerbrain/powerbrain.py` | +`get_phase_mode()`, +`set_charging_rules()`, +`get_charging_rules()`, +`get_phase_mode()` on Evse class; new API constants |
| `custom_components/powerbrain/__init__.py` | Register 5 new HA services |
| `custom_components/powerbrain/services.yaml` | Document all new services |
| `README.md` | Document new sensors, select entity, services with examples |

---

## Related Issues

- Closes #71 (phase mode configuration)
- Closes #83 (SOC / storage support)
- Related to #89, #90, #91 (charging rules)
